### PR TITLE
Non-jumping scrollbar hack (part 1)

### DIFF
--- a/header.php
+++ b/header.php
@@ -22,6 +22,7 @@ global $defaultoptions;
 		<a name="seitenmarke" id="seitenmarke"></a>
 
 		<header>
+		    <script type="text/javascript">var b=document.body.clientWidth;</script>
 		    <div id="kopf" <?php if (!empty(get_header_image())) : ?>  style="background-image: url(<?php header_image(); ?>)" <?php endif; ?>>  <!-- begin: kopf -->
 			<div id="logo">
 


### PR DESCRIPTION
The non-jumping scrollbar hack reads out the clientWidth before loading the website and saves it to var b. After loading the content, the clientWidth is read out again, substracted from the saved value and added as left padding.